### PR TITLE
restructure users & manage officers page

### DIFF
--- a/amplify/backend/api/parkrGql/schema.graphql
+++ b/amplify/backend/api/parkrGql/schema.graphql
@@ -36,6 +36,7 @@ type Officer @model {
     # id is userId from Cognito
     id: ID!
     role: String!
+    name: String!
     organization: Organization @belongsTo
 }
 

--- a/lib/gateway.dart
+++ b/lib/gateway.dart
@@ -4,6 +4,7 @@ import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:flutter/foundation.dart';
 import 'package:parkr/models/ModelProvider.dart';
+import 'package:parkr/user.dart';
 
 class Gateway {
   static final Gateway _instance = Gateway._privateConstructor();
@@ -93,10 +94,9 @@ class Gateway {
     }
   }
 
-  // provide the userId created by cognito
-  Future<Officer?> addOfficer(String userId) async {
+  Future<Officer?> _addOfficer(String userId, String role) async {
     try {
-      final officer = Officer(id: userId, role: "officer");
+      final officer = Officer(id: userId, role: role, name: CurrentUser().getFullName());
       final request = ModelMutations.create(officer);
       final response = await Amplify.API.mutate(request: request).response;
 
@@ -114,12 +114,18 @@ class Gateway {
     }
   }
 
-  Future<Officer?> addAdmin(String userId) async {
-    try {
-      final admin = Officer(id: userId, role: "admin");
-      final request = ModelMutations.create(admin);
-      final response = await Amplify.API.mutate(request: request).response;
+  Future<Officer?> addOfficer(String userId) async {
+    return await _addOfficer(userId, "officer");
+  }
 
+  Future<Officer?> addAdmin(String userId) async {
+    return await _addOfficer(userId, "admin");
+  }
+
+  Future<Officer?> removeOfficer(String userId) async {
+    try {
+      final request = ModelMutations.deleteById(Officer.classType, userId);
+      final response = await Amplify.API.mutate(request: request).response;
       if (response.data == null) {
         if (kDebugMode) {
           print('errors: ' + response.errors.toString());

--- a/lib/models/ModelProvider.dart
+++ b/lib/models/ModelProvider.dart
@@ -40,7 +40,7 @@ export 'Tickets.dart';
 
 class ModelProvider implements ModelProviderInterface {
   @override
-  String version = "0d24f385fcfe7f0e06e495d5cf590611";
+  String version = "32b035e98cb036189277c1d28e925fda";
   @override
   List<ModelSchema> modelSchemas = [AppKeys.schema, Officer.schema, Organization.schema, ParkingPermits.schema, Tickets.schema];
   static final ModelProvider _instance = ModelProvider();

--- a/lib/models/Officer.dart
+++ b/lib/models/Officer.dart
@@ -30,6 +30,7 @@ class Officer extends Model {
   static const classType = const _OfficerModelType();
   final String id;
   final String? _role;
+  final String? _name;
   final Organization? _organization;
   final TemporalDateTime? _createdAt;
   final TemporalDateTime? _updatedAt;
@@ -55,6 +56,19 @@ class Officer extends Model {
     }
   }
   
+  String get name {
+    try {
+      return _name!;
+    } catch(e) {
+      throw new AmplifyCodeGenModelException(
+          AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
+            AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString()
+          );
+    }
+  }
+  
   Organization? get organization {
     return _organization;
   }
@@ -67,12 +81,13 @@ class Officer extends Model {
     return _updatedAt;
   }
   
-  const Officer._internal({required this.id, required role, organization, createdAt, updatedAt}): _role = role, _organization = organization, _createdAt = createdAt, _updatedAt = updatedAt;
+  const Officer._internal({required this.id, required role, required name, organization, createdAt, updatedAt}): _role = role, _name = name, _organization = organization, _createdAt = createdAt, _updatedAt = updatedAt;
   
-  factory Officer({String? id, required String role, Organization? organization}) {
+  factory Officer({String? id, required String role, required String name, Organization? organization}) {
     return Officer._internal(
       id: id == null ? UUID.getUUID() : id,
       role: role,
+      name: name,
       organization: organization);
   }
   
@@ -86,6 +101,7 @@ class Officer extends Model {
     return other is Officer &&
       id == other.id &&
       _role == other._role &&
+      _name == other._name &&
       _organization == other._organization;
   }
   
@@ -99,6 +115,7 @@ class Officer extends Model {
     buffer.write("Officer {");
     buffer.write("id=" + "$id" + ", ");
     buffer.write("role=" + "$_role" + ", ");
+    buffer.write("name=" + "$_name" + ", ");
     buffer.write("organization=" + (_organization != null ? _organization!.toString() : "null") + ", ");
     buffer.write("createdAt=" + (_createdAt != null ? _createdAt!.format() : "null") + ", ");
     buffer.write("updatedAt=" + (_updatedAt != null ? _updatedAt!.format() : "null"));
@@ -107,16 +124,18 @@ class Officer extends Model {
     return buffer.toString();
   }
   
-  Officer copyWith({String? id, String? role, Organization? organization}) {
+  Officer copyWith({String? id, String? role, String? name, Organization? organization}) {
     return Officer._internal(
       id: id ?? this.id,
       role: role ?? this.role,
+      name: name ?? this.name,
       organization: organization ?? this.organization);
   }
   
   Officer.fromJson(Map<String, dynamic> json)  
     : id = json['id'],
       _role = json['role'],
+      _name = json['name'],
       _organization = json['organization']?['serializedData'] != null
         ? Organization.fromJson(new Map<String, dynamic>.from(json['organization']['serializedData']))
         : null,
@@ -124,11 +143,12 @@ class Officer extends Model {
       _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
   
   Map<String, dynamic> toJson() => {
-    'id': id, 'role': _role, 'organization': _organization?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
+    'id': id, 'role': _role, 'name': _name, 'organization': _organization?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
   static final QueryField ID = QueryField(fieldName: "officer.id");
   static final QueryField ROLE = QueryField(fieldName: "role");
+  static final QueryField NAME = QueryField(fieldName: "name");
   static final QueryField ORGANIZATION = QueryField(
     fieldName: "organization",
     fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: (Organization).toString()));
@@ -140,6 +160,12 @@ class Officer extends Model {
     
     modelSchemaDefinition.addField(ModelFieldDefinition.field(
       key: Officer.ROLE,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.string)
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: Officer.NAME,
       isRequired: true,
       ofType: ModelFieldType(ModelFieldTypeEnum.string)
     ));

--- a/lib/user.dart
+++ b/lib/user.dart
@@ -125,9 +125,11 @@ class CurrentUser {
 
   String getFirstName() {
     final nameSections = getFullName().split(',');
-    if (nameSections.length == 1 && kDebugMode) {
-      print(
-          "YOU NEED TO UPDATE YOUR USER TO HAVE A LAST,FIRST NAME IN COGNITO");
+    if (nameSections.length == 1) {
+      if (kDebugMode) {
+        print(
+            "YOU NEED TO UPDATE YOUR USER TO HAVE A LAST,FIRST NAME IN COGNITO");
+      }
       return "NO_FIRSTNAME";
     }
     return nameSections[1];

--- a/lib/views/homepage.dart
+++ b/lib/views/homepage.dart
@@ -64,14 +64,17 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    final username = CurrentUser().getName();
+    final username = CurrentUser().getFirstName();
 
     return KeyboardVisibilityBuilder(builder: (context, isKeyboardVisible) {
       return Scaffold(
         appBar: AppBar(
-          automaticallyImplyLeading: false,
-          title: Text('Home - Welcome $username'),
-        ),
+            automaticallyImplyLeading: false,
+            title: Row(children: [
+              Text('Welcome, $username'),
+              const Spacer(),
+              const Text('Home'),
+            ])),
         body: Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -113,15 +116,20 @@ class _HomePageState extends State<HomePage> {
                             child: Transform.scale(
                               scale: scaler,
                               child: Center(
+                                  child: Container(
+                                decoration: BoxDecoration(
+                                  border:
+                                      Border.all(width: 1.0, color: Colors.red),
+                                ),
                                 child: CameraPreview(_camera),
-                              ),
+                              )),
                             ));
                       } else {
                         return const Center(child: CircularProgressIndicator());
                       }
                     },
                   )),
-              const Spacer(flex: 20),
+              const Spacer(flex: 22),
               Padding(
                   padding: const EdgeInsets.fromLTRB(0, 0, 40, 0),
                   child: TextFormField(

--- a/lib/views/manageofficerspage.dart
+++ b/lib/views/manageofficerspage.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:parkr/gateway.dart';
 import 'package:parkr/widgets/registerofficerdialog.dart';
 import 'package:parkr/models/Officer.dart';
+import 'package:parkr/user.dart';
+import 'package:parkr/widgets/loadingdialog.dart';
 
 class ManageOfficersPage extends StatefulWidget {
   const ManageOfficersPage({Key? key}) : super(key: key);
@@ -11,22 +13,46 @@ class ManageOfficersPage extends StatefulWidget {
 }
 
 class _ManageOfficersPageState extends State<ManageOfficersPage> {
-  Future<List<Widget>> _fetchOfficers() async {
-    // Place holder widget
-    final dbOfficers = await Gateway().listOfficers();
-    if (dbOfficers == null) {
-      return [];
-    }
-    return dbOfficers
-        .where((officer) => officer != null)
-        .map((officer) => (officer as Officer)) // from Officer?
-        .map((officer) => Text(officer.id + " : " + officer.role))
+  Future<List<Officer>> _fetchOfficers() async {
+    final currentUserId = (await CurrentUser().get()).userId;
+    return (await Gateway().listOfficers() ?? [])
+        .where((officer) => officer != null && officer.id != currentUserId)
+        .map((officer) => (officer as Officer))
         .toList();
+  }
+
+  Future<void> removeOfficer(BuildContext ctx, Officer o) async {
+    showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+              title: const Text('Remove Officer'),
+              content: Text("Are you sure you want to remove ${o.name}?"),
+              actions: [
+                TextButton(
+                  child: const Text('Cancel'),
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                  },
+                ),
+                TextButton(
+                  child: const Text('Remove'),
+                  onPressed: () async {
+                    Navigator.of(context).pop();
+                    await loadingDialog(
+                        context,
+                        Gateway().removeOfficer(o.id),
+                        "Removing ${o.name}...",
+                        "Success",
+                        "Failed to remove ${o.name}");
+                  },
+                ),
+              ]);
+        });
   }
 
   @override
   Widget build(BuildContext context) {
-    final officers = _fetchOfficers();
     return Scaffold(
         appBar: AppBar(
           title: const Text("Parking Officers"),
@@ -35,17 +61,22 @@ class _ManageOfficersPageState extends State<ManageOfficersPage> {
             child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: <Widget>[
-              FutureBuilder<List<Widget>>(
+              FutureBuilder<List<Officer>>(
                 future: _fetchOfficers(),
                 builder: (BuildContext context,
-                    AsyncSnapshot<List<Widget>> snapshot) {
+                    AsyncSnapshot<List<Officer>> snapshot) {
                   if (snapshot.hasError) {
                     print(snapshot.error);
                     return const Text(
                         "An Error Occurred Fetching Your Officers");
                   }
                   final officers =
-                      snapshot.hasData ? snapshot.data as List<Widget> : [];
+                      snapshot.hasData ? snapshot.data as List<Officer> : [];
+
+                  if (officers.isEmpty) {
+                    return const Expanded(child: Text("No Officers"));
+                  }
+
                   return Expanded(
                       child: ListView.separated(
                     shrinkWrap: true,
@@ -53,11 +84,28 @@ class _ManageOfficersPageState extends State<ManageOfficersPage> {
                     padding: const EdgeInsets.all(8),
                     itemCount: officers.length,
                     itemBuilder: (BuildContext context, int index) {
+                      final officer = officers[index];
                       return Container(
-                        height: 50,
-                        color: Colors.amber,
-                        child: Center(child: officers[index]),
-                      );
+                          height: 50,
+                          color: Colors.black54,
+                          child: Center(
+                              child: Row(children: [
+                            const Spacer(flex: 2),
+                            RichText(
+                                text: TextSpan(
+                                    style: const TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 20,
+                                        fontWeight: FontWeight.bold),
+                                    text: officer.name + ":  " + officer.role)),
+                            const Spacer(flex: 1),
+                            IconButton(
+                                color: Colors.white,
+                                icon: const Icon(Icons.delete),
+                                onPressed: () async {
+                                  await removeOfficer(context, officer);
+                                }),
+                          ])));
                     },
                     separatorBuilder: (BuildContext context, int index) =>
                         const Divider(),

--- a/lib/views/platepage.dart
+++ b/lib/views/platepage.dart
@@ -96,7 +96,7 @@ class _PlatePageState extends State<PlatePage> {
   Widget build(BuildContext context) {
     final arguments = (ModalRoute.of(context)?.settings.arguments as Map);
     final registration = arguments["reg"] as Registration;
-    final username = CurrentUser().getName();
+    final username = CurrentUser().getFirstName();
     _hasPass = registration.verified;
     valid = (_hasPass && !_invalidLot && !_blocking && !_multiple && !_alt);
 
@@ -201,7 +201,7 @@ class _PlatePageState extends State<PlatePage> {
                         children: [
                           const SizedBox(height: 50),
                           const Text('Parking Officer'),
-                          Text(username!,
+                          Text(username,
                               style:
                                   const TextStyle(fontWeight: FontWeight.bold)),
                           const SizedBox(height: 50),
@@ -224,22 +224,25 @@ class _PlatePageState extends State<PlatePage> {
               Expanded(
                 child: SizedBox(
                   height: 40,
-                  child: valid ?
-                      const Icon(Icons.check, color: Colors.green, size: 80.0) :
-                      const Icon(Icons.error, color: Colors.red, size: 80.0),
+                  child: valid
+                      ? const Icon(Icons.check, color: Colors.green, size: 80.0)
+                      : const Icon(Icons.error, color: Colors.red, size: 80.0),
                 ),
               ),
               Expanded(
                 child: SizedBox(
-                  height: 10,
-                  child: valid ?
-                  const Text('Valid',
-                      style:
-                      TextStyle(fontWeight: FontWeight.bold, color: Colors.green, fontSize: 45)) :
-                  const Text('Invalid',
-                      style:
-                      TextStyle(fontWeight: FontWeight.bold, color: Colors.red, fontSize: 45))
-                ),
+                    height: 10,
+                    child: valid
+                        ? const Text('Valid',
+                            style: TextStyle(
+                                fontWeight: FontWeight.bold,
+                                color: Colors.green,
+                                fontSize: 45))
+                        : const Text('Invalid',
+                            style: TextStyle(
+                                fontWeight: FontWeight.bold,
+                                color: Colors.red,
+                                fontSize: 45))),
               ),
               Column(
                 mainAxisAlignment: MainAxisAlignment.end,

--- a/lib/widgets/loginform.dart
+++ b/lib/widgets/loginform.dart
@@ -71,7 +71,6 @@ class _LoginFormState extends State<LoginForm> {
                 ]);
           });
       if (signedIn) {
-        await CurrentUser().update();
         final user = await CurrentUser().get();
         await Gateway().addOfficer(user.userId);
       }

--- a/lib/widgets/registerorgform.dart
+++ b/lib/widgets/registerorgform.dart
@@ -26,7 +26,8 @@ class _RegisterOrgFormState extends State<RegisterOrgForm> {
   final _formKey = GlobalKey<FormState>();
 
   Future<Object?> registerAdmin(BuildContext context) async {
-    await registerOfficer(emailCtrl.text, firstNameCtrl.text, lastNameCtrl.text, passCtrl.text);
+    await registerOfficer(
+        emailCtrl.text, firstNameCtrl.text, lastNameCtrl.text, passCtrl.text);
 
     // process login
     bool signedIn = false;
@@ -62,7 +63,8 @@ class _RegisterOrgFormState extends State<RegisterOrgForm> {
                     onPressed: () async {
                       final res = await confirmUser(emailCtrl.text, code);
                       if (res.isSignUpComplete) {
-                        signedIn = await signInUser(emailCtrl.text, passCtrl.text);
+                        signedIn =
+                            await signInUser(emailCtrl.text, passCtrl.text);
                       }
                       Navigator.of(context).pop();
                     },
@@ -73,7 +75,6 @@ class _RegisterOrgFormState extends State<RegisterOrgForm> {
     if (!signedIn) {
       return null;
     }
-    await CurrentUser().update();
     final user = await CurrentUser().get();
     await Gateway().addAdmin(user.userId);
     return "Success";


### PR DESCRIPTION
- always call CurrentUser().update() when freshening CurrentUser().get()
- add name to gql schema of an officer, in lastname,firstname format (same as cognito)
- provide ability to remove officers
- freshen manage officers page to have officer name and a remove officer button

Ensure to review my changes to user.dart. I've explicitly separated first and last names, because "name" wasn't very clear, when cognito stores the name as `<lastname>,<firstname>`. When dealing with the new 'name' field in GQL, I needed to make sure I was using the correct name (`<lastname>,<firstname>`). It should be more clear as to which you are getting, now.